### PR TITLE
Implement Powder selection menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project ("BlackPowder")
 add_subdirectory(lib/piksel)
 
 # Add source to this project's executable.
-add_executable (BlackPowder "src/App.cpp" "src/GameMaster.cpp" "src/Storage.cpp" "src/powders/Sand.cpp" "src/powders/Water.cpp" "src/powders/Powder.cpp")
+add_executable (BlackPowder "src/App.cpp" "src/GameMaster.cpp" "src/Storage.cpp" "src/Menu.cpp" "src/powders/Sand.cpp" "src/powders/Water.cpp" "src/powders/Powder.cpp")
 
 set(CMAKE_CXX_STANDARD C++20)
 

--- a/inc/GameMaster.h
+++ b/inc/GameMaster.h
@@ -5,15 +5,28 @@
 #include <memory>
 
 #include "piksel/baseapp.hpp"
+#include "piksel/graphics.hpp"
+#include "Menu.h"
 #include "Powder.h"
 #include "Storage.h"
 
 class GameMaster {
     private:
+        std::unique_ptr<Menu> selectionMenu;
         /**
          * Stores all necessary data about powders currently in the simulation
          */
         std::shared_ptr<Storage> powderStorage;
+        /**
+         * Dimensions of the game window
+         */
+        int windowWidth;
+        int windowHeight;
+        /**
+         * Dimensions of the space where powders can exist
+         */
+        int powderSpaceWidth;
+        int powderSpaceHeight;
         /**
          * The current location of the mouse cursor
          */
@@ -32,8 +45,13 @@ class GameMaster {
          */
         void mouseButtonChanged(int button, bool pressed);
 
+        /**
+         * Draws the selection menu
+         */
+        std::pair<int,int> drawMenu();
+
     public:
-        GameMaster();
+        GameMaster(int windowHeight, int windowWidth);
         ~GameMaster();
 
         /**

--- a/inc/Menu.h
+++ b/inc/Menu.h
@@ -1,0 +1,68 @@
+#ifndef MENU_H
+#define MENU_H
+
+#include "piksel/graphics.hpp"
+#include "Powder.h"
+
+class Menu {
+    private:
+        class MenuButton {
+            public:
+                static const int BUTTON_HEIGHT = 30;
+                static const int BUTTON_WIDTH = 100;
+
+                bool selected;
+                const std::pair<int,int> topLeft;
+                const std::pair<int,int> bottomRight;
+                const glm::vec4 color;
+                const std::string name;
+
+                MenuButton(std::pair<int,int> topLeftCorner, std::pair<int,int> bottomRightCorner, glm::vec4 color, std::string name, bool selected = false) :
+                        topLeft(topLeftCorner),
+                        bottomRight(bottomRightCorner),
+                        color(color),
+                        name(name),
+                        selected(selected) {
+                }
+                ~MenuButton() {}
+                
+                void draw(piksel::Graphics& g) {
+                    // Assumes rectMode == CORNERS
+                    g.stroke(color);
+                    g.rect(topLeft.first, topLeft.second, bottomRight.first, bottomRight.second);
+                    g.text(name, topLeft.first + 5, (topLeft.second + bottomRight.second)/2 + 10);
+                }
+
+                bool isClickInBounds(int xPos, int yPos) {
+                    if(xPos >= topLeft.first && xPos <= bottomRight.first &&
+                       yPos >= topLeft.second && xPos <= bottomRight.second) {
+                       return true;
+                    }
+                    return false;
+                }
+        };
+
+        const int windowWidth;
+        const int windowHeight;
+
+        const int menuHeight;
+        const int menuWidth;
+
+        std::vector<MenuButton> menuButtons;
+
+        std::string curMenuSelection;
+
+    public:
+        Menu(int windowWidth, int windowHeight, std::shared_ptr<std::vector<std::shared_ptr<Powder::Powder>>> powderTypesList);
+        ~Menu();
+
+        void draw(piksel::Graphics& g);
+
+        std::pair<int,int> getMenuDimensions();
+
+        std::string getCurrentSelection();
+
+        void clicked(int mouseX, int mouseY);
+};
+
+#endif // MENU_H

--- a/inc/Powders/Powder.h
+++ b/inc/Powders/Powder.h
@@ -14,12 +14,13 @@ namespace Powder
 
     class Powder {
         protected:
-            Powder(int xPos, int yPos, bool gravity, float density, glm::vec4 color) :
+            Powder(int xPos, int yPos, bool gravity, float density, glm::vec4 color, std::string name) :
                     x(xPos),
                     y(yPos),
                     gravity(gravity),
                     density(density),
                     color(color),
+                    name(name),
                     changedThisFrame(false) {}
 
             /** 
@@ -38,6 +39,12 @@ namespace Powder
              * Color of the powder
              */
             const glm::vec4 color;
+            /**
+             * Name of the powder
+             * 
+             * The name is the same for all instances of a powder, but needs to be accessible by things that don't know the powder type so shouldn't be static
+             */
+            const std::string name;
             /**
              * X coordinate
              */
@@ -79,6 +86,10 @@ namespace Powder
 
             bool getChanged() {
                 return(changedThisFrame);
+            }
+
+            std::string getName() {
+                return name;
             }
 
             /**

--- a/inc/Powders/Sand.h
+++ b/inc/Powders/Sand.h
@@ -15,6 +15,8 @@ namespace Powder {
             powder_ptr copyPowder();
 
             powder_ptr copyPowder(int newXPos, int newYPos);
+
+            std::string getName();
     };
 }
 

--- a/inc/Powders/Water.h
+++ b/inc/Powders/Water.h
@@ -15,6 +15,8 @@ namespace Powder {
             powder_ptr copyPowder();
 
             powder_ptr copyPowder(int newXPos, int newYPos);
+
+            std::string getName();
     };
 }
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -18,7 +18,7 @@ App::App(int width, int height, std::string title) : piksel::BaseApp(width, heig
 App::~App() {}
 
 void App::initialize() {
-    this->gm = std::make_unique<GameMaster>();
+    this->gm = std::make_unique<GameMaster>(width, height);
 }
 
 void App::setup() {
@@ -43,7 +43,10 @@ void App::mouseReleased(int button) {
 }
 
 int main() {
-	std::unique_ptr<App> app = std::make_unique<App>(800, 800, "Black Powder");
+    const int WINDOW_WIDTH = 800;
+    const int WINDOW_HEIGHT = 800;
+
+	std::unique_ptr<App> app = std::make_unique<App>(WINDOW_WIDTH, WINDOW_HEIGHT, "Black Powder");
     //App app("Black Powder", false);
 	app->start();
 }

--- a/src/GameMaster.cpp
+++ b/src/GameMaster.cpp
@@ -21,19 +21,30 @@ std::pair<int,int> advancePowderFrame(int x, int y, bool gravity, float density)
     return position;
 }
 
-GameMaster::GameMaster() {
+GameMaster::GameMaster(int windowWidth, int windowHeight) {
+    this->windowWidth = windowWidth;
+    this->windowHeight = windowHeight;
     powderStorage = std::make_shared<Storage>();
     curMouseLocation = std::make_pair(0,0);
     lmbPressed = false;
     rmbPressed = false;
 
+    std::shared_ptr<std::vector<powder_ptr>> menuPowders = std::shared_ptr<std::vector<powder_ptr>>(new std::vector<powder_ptr>());
+    menuPowders->push_back(std::shared_ptr<Powder::Sand>(new Powder::Sand(0,0)));
+    menuPowders->push_back(std::shared_ptr<Powder::Water>(new Powder::Water(0,0)));
+    selectionMenu = std::unique_ptr<Menu>(new Menu(this->windowWidth, this->windowHeight, menuPowders));
+    menuPowders.reset();
+    
+    powderSpaceWidth = this->windowWidth;
+    powderSpaceHeight = this->windowHeight - selectionMenu->getMenuDimensions().second;
+
     for(int i = 0; i < 10000; i++) {
         int typeRand = rand() % 2;
         bool success = false;
         if(typeRand == 0)
-            success = powderStorage->addPowder(std::make_shared<Powder::Sand>(rand()%800, rand()%800));
+            success = powderStorage->addPowder(std::make_shared<Powder::Sand>(rand()%800, rand()%700));
         else if(typeRand == 1)
-            success = powderStorage->addPowder(std::make_shared<Powder::Water>(rand()%800, rand()%200+600));
+            success = powderStorage->addPowder(std::make_shared<Powder::Water>(rand()%800, rand()%200+500));
         i = success ? i : i-1;
     }
 }
@@ -41,18 +52,41 @@ GameMaster::GameMaster() {
 GameMaster::~GameMaster() {}
 
 void GameMaster::run(piksel::Graphics& g) {
+    // Draw powder selection menu
+    selectionMenu->draw(g);
+
     // Create new powders via user
     if(lmbPressed) {
-        powder_ptr toAdd = std::make_shared<Powder::Sand>(curMouseLocation.first,curMouseLocation.second);
-        powderStorage->addPowder(toAdd);
+        if(curMouseLocation.second <= powderSpaceHeight) {
+            // TODO Make a Factory for Powders to do this logic
+            powder_ptr toAdd;
+            if(selectionMenu->getCurrentSelection() == "Sand") {
+                toAdd = std::make_shared<Powder::Sand>(curMouseLocation.first,curMouseLocation.second);
+            }
+            else if(selectionMenu->getCurrentSelection() == "Water") {
+                toAdd = std::make_shared<Powder::Water>(curMouseLocation.first,curMouseLocation.second);
+            }
+
+            if(toAdd) {
+                powderStorage->addPowder(toAdd);
+            } else {
+                printf("WARNING: Selection menu indicated a powder that we couldn't make: %s\n", selectionMenu->getCurrentSelection().c_str());
+            }
+        }
+        else if(curMouseLocation.second > powderSpaceHeight) {
+            selectionMenu->clicked(curMouseLocation.first, curMouseLocation.second);
+        }
+        
     }
     else if(rmbPressed) {
-        try{
-            std::shared_ptr<std::vector<powder_ptr>> toRemove = std::make_shared<std::vector<std::shared_ptr<Powder::Powder>>>();
-            toRemove->push_back(powderStorage->getPowderAtLocation(curMouseLocation.first,curMouseLocation.second));
-            powderStorage->removePowders(toRemove);
-        } catch(std::out_of_range e) {
-            //No powders at cursor, nothing to remove
+        if(curMouseLocation.second <= powderSpaceHeight) {
+            try{
+                std::shared_ptr<std::vector<powder_ptr>> toRemove = std::make_shared<std::vector<std::shared_ptr<Powder::Powder>>>();
+                toRemove->push_back(powderStorage->getPowderAtLocation(curMouseLocation.first,curMouseLocation.second));
+                powderStorage->removePowders(toRemove);
+            } catch(std::out_of_range e) {
+                //No powders at cursor, nothing to remove
+            }
         }
     }
     
@@ -70,9 +104,14 @@ void GameMaster::run(piksel::Graphics& g) {
     }
     
     // Draw all the powders
-    //printf("Drawing Powders\n");
     for(int_powder_map::iterator iter = beginIter; iter != endIter; iter++) {
-        iter->second->draw(g);
+        std::pair<int,int> pos = iter->second->getPosition();
+        if(pos.first < 1 || pos.first > this->powderSpaceWidth ||
+            pos.second < 1 || pos.second > this->powderSpaceHeight) {
+            powderStorage->removePowder(iter->second);
+        } else {
+            iter->second->draw(g);
+        }
     }
 
     powderStorage->endFrameHandling();

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1,0 +1,52 @@
+#include "Menu.h"
+#include "piksel/graphics.hpp"
+#include "Powder.h"
+
+
+Menu::Menu(int windowWidth, int windowHeight, std::shared_ptr<std::vector<std::shared_ptr<Powder::Powder>>> powderTypesList) :
+        windowWidth(windowWidth),
+        windowHeight(windowHeight),
+        menuWidth(windowWidth),
+        menuHeight(100),
+        curMenuSelection("Sand") {
+    std::pair<int,int> nextTopLeft = std::make_pair(0, windowHeight - menuHeight);
+    for(std::vector<std::shared_ptr<Powder::Powder>>::iterator iter = powderTypesList->begin(); iter != powderTypesList->end(); iter++) {
+        menuButtons.push_back(MenuButton(nextTopLeft, std::make_pair(nextTopLeft.first + Menu::MenuButton::BUTTON_WIDTH, nextTopLeft.second + Menu::MenuButton::BUTTON_HEIGHT), (*iter)->getColor(), (*iter)->getName()));
+        nextTopLeft.first = nextTopLeft.first + Menu::MenuButton::BUTTON_WIDTH;
+    }
+}
+
+Menu::~Menu() {}
+
+void Menu::draw(piksel::Graphics& g) {
+    g.push();
+    g.rectMode(piksel::DrawMode::CORNERS);
+    g.noFill();
+    for(std::vector<MenuButton>::iterator iter = menuButtons.begin(); iter != menuButtons.end(); iter++) {
+        g.push();
+        if(getCurrentSelection() == iter->name) {
+            g.strokeWeight(2.0f);
+        }
+        iter->draw(g);
+        g.pop();
+    }
+
+    g.pop();
+}
+
+std::pair<int,int> Menu::getMenuDimensions() {
+    return std::make_pair(menuWidth, menuHeight);
+}
+
+std::string Menu::getCurrentSelection() {
+    return curMenuSelection;
+}
+
+void Menu::clicked(int mouseX, int mouseY) {
+    for(std::vector<MenuButton>::iterator iter = menuButtons.begin(); iter != menuButtons.end(); iter++) {
+        if(iter->isClickInBounds(mouseX, mouseY)) {
+            curMenuSelection = iter->name;
+            break;
+        }
+    }
+}

--- a/src/powders/Powder.cpp
+++ b/src/powders/Powder.cpp
@@ -12,7 +12,8 @@ bool Powder::Powder::advanceOneFrame(std::function<std::pair<int,int>(int,int,bo
         std::pair<int,int> newPos = advanceFun(x, y, gravity, density);
         std::shared_ptr<Powder> displacedPowder = NULL;
         // Don't let powder exit the screen
-        if(!(newPos.first > 800 || newPos.second > 800 || newPos.first < 1 || newPos.second < 1)) {
+        // At some point we'll draw walls around the edges when we don't want powders leaving the screen
+        if(!(newPos.first > 800 || newPos.second > 700 || newPos.first < 1 || newPos.second < 1)) {
             try {
                 std::shared_ptr<Powder> overlap = powderStorage->getPowderAtLocation(newPos.first, newPos.second);
                 if(this->density <= overlap->getDensity()) {

--- a/src/powders/Sand.cpp
+++ b/src/powders/Sand.cpp
@@ -6,7 +6,7 @@
 #include "Powder.h"
 
 Powder::Sand::Sand(int xPos, int yPos) : 
-        Powder::Powder(xPos, yPos, true, .75f, glm::vec4(1.0f,.984f,0.0f,1.0f)) {
+        Powder::Powder(xPos, yPos, true, .75f, glm::vec4(1.0f,.984f,0.0f,1.0f), "Sand") {
 }
 
 Powder::Sand::~Sand() {}

--- a/src/powders/Water.cpp
+++ b/src/powders/Water.cpp
@@ -6,7 +6,7 @@
 #include "Powder.h"
 
 Powder::Water::Water(int xPos, int yPos) : 
-        Powder::Powder(xPos, yPos, true, .25f, glm::vec4(0.102f, 0.102f, 0.969f, 1.0f)) {
+        Powder::Powder(xPos, yPos, true, .25f, glm::vec4(0.102f, 0.102f, 0.969f, 1.0f), "Water") {
 }
 
 Powder::Water::~Water() {}


### PR DESCRIPTION
Bolded menu item is selected, Sand is default. Powder drawing bounds are limited to the space not taken by the Menu.

Powders are still hardcoded to not exit their Powder Space, so if the menu changes size, that has to be changed manually.