### PR TITLE
Define class for handling complex interactions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ add_subdirectory(lib/piksel)
 add_executable (BlackPowder
                 "src/App.cpp"
                 "src/GameMaster.cpp"
+                "src/Interactions.cpp"
                 "src/Menu.cpp"
                 "src/Storage.cpp"
                 "src/powders/Powder.cpp"

--- a/inc/Interactions.h
+++ b/inc/Interactions.h
@@ -1,0 +1,26 @@
+#ifndef INTERACTIONS_H
+#define INTERACTIONS_H
+
+#include "Powder.h"
+#include "Storage.h"
+#include "Wall.h"
+#include "Water.h"
+
+class Interactions {
+    public:
+        /**
+         * Determines interaction between two generic Powders. This is the generic case that will be hit
+         * if there is not a more specific interact() method for the called case. No special interaction
+         * will take place and the return value will always be false.
+         * 
+         * @param powder1 One of the powders in the interaction
+         * @param powder2 One of the powders in the interaction
+         * @param firstMoved If true, then powder1 is attempting to shift into powder2's space, if false then vice versa
+         *                      Useful for permitting symmetry between interact() methods of the same two Powders
+         * 
+         * @return False
+         */
+        static bool interact(std::shared_ptr<Powder::Powder> powder1, std::shared_ptr<Powder::Powder> powder2, bool firstPowderMoved, std::shared_ptr<Storage> powderStorage);
+};
+
+#endif

--- a/src/Interactions.cpp
+++ b/src/Interactions.cpp
@@ -1,0 +1,18 @@
+#include "Interactions.h"
+#include "Powder.h"
+
+bool Interactions::interact(std::shared_ptr<Powder::Powder> powder1,
+                            std::shared_ptr<Powder::Powder> powder2,
+                            bool firstPowderMoved,
+                            std::shared_ptr<Storage> powderStorage) {
+    /* Leaving this is as an example since there aren't any special interactions rn
+    if(powder1->getName() == "Water" || powder2->getName() == "Water") {
+        if(powder1->getName() == "Wall" || powder2->getName() == "Wall") {
+            
+        }
+    }
+    */
+
+    // Interactions between two powders should generally be covered by generic gravity/density/etc. determinations
+    return false;
+}


### PR DESCRIPTION
Complex interactions are anything that wouldn't follow the basic rules of gravity/density/etc. (Like fire burning something).

Avoid handling a lack of gravity in both GameMaster's physics function and Powder's frame advance method.