### PR TITLE
Add powder velocities

### DIFF
--- a/inc/Powders/Powder.h
+++ b/inc/Powders/Powder.h
@@ -22,7 +22,7 @@ namespace Powder
             };
 
         protected:
-            Powder(int xPos, int yPos, bool gravity, float density, glm::vec4 color, PowderType powderType, int halfLife = 0);
+            Powder(int xPos, int yPos, bool gravity, float density, glm::vec4 color, PowderType powderType, int halfLife = 0, bool liquid = false);
 
             /**
              * Table for translating the powder type into a name string
@@ -45,6 +45,10 @@ namespace Powder
              */
             const glm::vec4 color;
             /**
+             * True if the powder is a liquid
+             */
+            const bool liquid;
+            /**
              * Type of the powder
              * 
              * The type is the same for all instances of a powder, but needs to be accessible by things that don't know the powder type so shouldn't be static
@@ -58,6 +62,14 @@ namespace Powder
              * Y coordinate
              */
             int y;
+            /**
+             * Horizontal Velocity
+             */
+            double xVel;
+            /**
+             * Vertical velocity
+             */
+            double yVel;
             /**
              * Half life of this powder, or how many frames on average it should exist before disappearing
              * If set to 0, this powder does not have a half life and can exist indefinitely
@@ -80,6 +92,11 @@ namespace Powder
              * Returns position as [x,y]
              */
             std::pair<int,int> getPosition();
+            std::pair<double,double> getVelocities();
+            /**
+             * "Combines" the velocities of this object with the velocities provided
+             */
+            void combineVelocities(std::pair<double,double> velocities);
             void setChanged();
             bool getChanged();
             std::string getName();
@@ -99,7 +116,7 @@ namespace Powder
              * 
              * @return true if powder was advanced, false otherwise
              */
-            bool advanceOneFrame(std::function<std::pair<int,int>(int,int,bool,float)> advanceFun, std::shared_ptr<Storage> powderStorage);
+            bool advanceOneFrame(std::function<std::pair<int,int>(int,int,double,double)> advanceFun, std::shared_ptr<Storage> powderStorage);
 
             /**
              * Shift the powder to a new location.

--- a/src/GameMaster.cpp
+++ b/src/GameMaster.cpp
@@ -10,19 +10,14 @@
 #include "Wall.h"
 #include "Water.h"
 
-std::pair<int,int> advancePowderFrame(int x, int y, bool gravity, float density) {
-    std::pair<int,int> position = std::make_pair(x,y);
-    if(gravity) {
-        int rng = pow(rand()%10, 2);
-        int yMove = density >= 0 ? 1 : -1;
-        if(rng < abs(density*100)) {
-            position.second = y + yMove;
-        }
-        else {
-            position.first = x + ((rand() % 3) - 1);
-        }
-    }
+std::pair<int,int> advancePowderFrame(int x, int y, double xVelocity, double yVelocity) {
+    const int MAX_RNG = 100;
+    int rngX = rand() % MAX_RNG;
+    int rngY = rand() % MAX_RNG;
+    x += rngX < (abs(xVelocity) * MAX_RNG) ? (xVelocity / abs(xVelocity)) : 0;
+    y += rngY < (abs(yVelocity) * MAX_RNG) ? (yVelocity / abs(yVelocity)) : 0;
 
+    std::pair<int,int> position = std::make_pair(x,y);
     return position;
 }
 

--- a/src/GameMaster.cpp
+++ b/src/GameMaster.cpp
@@ -14,6 +14,9 @@ std::pair<int,int> advancePowderFrame(int x, int y, double xVelocity, double yVe
     const int MAX_RNG = 100;
     int rngX = rand() % MAX_RNG;
     int rngY = rand() % MAX_RNG;
+    // TODO Change location directly by velocity (instead of via whole numbers and rng)
+    //    Requires handling position as decimal value (else velocities <.5 will never let a powder move)
+    //    Requires either preventing velocities from being >1 or handling determining encounters at end location and in-between locations
     x += rngX < (abs(xVelocity) * MAX_RNG) ? (xVelocity / abs(xVelocity)) : 0;
     y += rngY < (abs(yVelocity) * MAX_RNG) ? (yVelocity / abs(yVelocity)) : 0;
 

--- a/src/powders/Water.cpp
+++ b/src/powders/Water.cpp
@@ -6,7 +6,7 @@
 #include "Powder.h"
 
 Powder::Water::Water(int xPos, int yPos) : 
-        Powder::Powder(xPos, yPos, true, .25f, glm::vec4(0.102f, 0.102f, 0.969f, 1.0f), PowderType::water) {
+        Powder::Powder(xPos, yPos, true, .4f, glm::vec4(0.102f, 0.102f, 0.969f, 1.0f), PowderType::water, 0, true) {
 }
 
 Powder::Water::~Water() {}


### PR DESCRIPTION
Movements of powders are now dependent on velocities instead of randomly determined each frame depending on their densities. Powders can also transfer their velocities to other powders that they touch.

Makes liquids more likely to flow when in a "pile" by forcing them to shift horizontally more often when at in impermeable surface